### PR TITLE
varint: Fix VarInt serialization and deserialization

### DIFF
--- a/tests/simple_config_default.rs
+++ b/tests/simple_config_default.rs
@@ -36,13 +36,13 @@ fn simple_struct() {
 
     // type         size
     // u8           1
-    // u16          2
-    // u32          4
-    // u64          8
-    // u128         16
+    // u16          1
+    // u32          1
+    // u64          1
+    // u128         1
     // Option<u8>   1 + 1
     // [u8; 3]      3 (fixed array so no length)
-    assert_eq!(1 + 2 + 4 + 8 + 16 + 1 + 1 + 3, writer.written_len());
+    assert_eq!(1 + 1 + 1 + 1 + 1 + 1 + 1 + 3, writer.written_len());
 
     let deserialized: TestStruct = deserialize(&buffer[..], options).unwrap();
     assert_eq!(s, deserialized);
@@ -59,11 +59,11 @@ fn simple_tuple() {
     println!("Buffer: {:?}", writer.written_buffer());
 
     // type         size
-    // u16          2
-    // u32          4
+    // u16          1
+    // u32          1
     // &[u8]        1 (len) + 4 (byte content)
     // &str         1 (len) + 4 (str content)
-    assert_eq!(2 + 4 + 1 + 4 + 1 + 4, writer.written_len());
+    assert_eq!(1 + 1 + 1 + 4 + 1 + 4, writer.written_len());
 
     let deserialized: (u16, u32, &[u8], &str) = deserialize(&buffer[..], options).unwrap();
     assert_eq!(s, deserialized);


### PR DESCRIPTION
VarInt was skipped for all primitives. Align it with main bincode
code base. Rename simple tests as fixint.

Fixes #4 