### PR TITLE
Adding std feature (to disable no_std)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,46 @@ jobs:
           command: test
           args: --features alloc
 
+  test_std:
+    name: Test std
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features std
+
+  test_alloc_std:
+    name: Test alloc and std
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features alloc,std
+
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ serde_derive = "1.0"
 [features]
 default = []
 alloc = ["serde/alloc"]
+
+# The std feature is necessary when compiling serde with std
+std = []

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -7,6 +7,9 @@ use serde::{de::*, serde_if_integer128};
 // #[cfg(feature = "alloc")]
 // use alloc::{string::String, vec::Vec};
 
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+
 /// Deserialize a given object from the given [CoreRead] object.
 ///
 /// Rust will detect the first two generic arguments automatically. The third generic argument
@@ -140,6 +143,9 @@ impl<'a, R: CoreRead<'a>> Error for DeserializeError<'a, R> {
         panic!("Custom error thrown: {}", _cause);
     }
 }
+
+#[cfg(feature = "std")]
+impl<'a, R: CoreRead<'a>> StdError for DeserializeError<'a, R> {}
 
 /// A deserializer that can be used to deserialize any `serde::Deserialize` type from a given
 /// [CoreRead] reader.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! Embedded bincode
 //!
@@ -19,6 +19,8 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 /// Contains helper structs to customize the way your structs are (de)serialized.
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! Embedded bincode
 //!

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -2,6 +2,9 @@ use super::*;
 use config::{BincodeByteOrder, IntEncoding, Options};
 use serde::{ser::*, serde_if_integer128};
 
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+
 /// Serialize a given `T` type into a given `CoreWrite` writer with the given `B` byte order.
 ///
 /// `T` can be any value that derives `serde::Serialize`.
@@ -81,6 +84,9 @@ impl<W: CoreWrite> serde::ser::Error for SerializeError<W> {
         panic!("Custom error: {}", _cause);
     }
 }
+
+#[cfg(feature = "std")]
+impl<W: CoreWrite> StdError for SerializeError<W> {}
 
 /// A serializer that can serialize any value that implements `serde::Serialize` into a given
 /// [CoreWrite] writer.

--- a/src/traits/core_read.rs
+++ b/src/traits/core_read.rs
@@ -1,5 +1,8 @@
 use core::str;
 
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+
 /// A target that can be read from. This is similar to `std::io::Read`, but the std trait is not
 /// available in `#![no_std]` projects.
 ///
@@ -106,3 +109,6 @@ impl core::fmt::Display for SliceReadError {
         write!(fmt, "{:?}", self)
     }
 }
+
+#[cfg(feature = "std")]
+impl StdError for SliceReadError {}


### PR DESCRIPTION
- When adding bincode-core as a dependency where std is required
- StdError must be defined per the serde crate when using std
  From serde:
  declare_error_trait!(Error: Sized + StdError);